### PR TITLE
Fix #52 bounding box not being initially updated

### DIFF
--- a/src/main/java/org/cloudwarp/probablychests/utils/PCMimicCreationUtils.java
+++ b/src/main/java/org/cloudwarp/probablychests/utils/PCMimicCreationUtils.java
@@ -68,8 +68,7 @@ public class PCMimicCreationUtils {
 			}
 		}
 		mimic.setType(type);
-		mimic.setPos(pos.getX() + 0.5D, pos.getY() + 0.1D, pos.getZ() + 0.5D);
-		mimic.setYaw(state.get(FACING).asRotation());
+		mimic.refreshPositionAndAngles(pos, state.get(FACING).asRotation(), mimic.getPitch());
 		mimic.headYaw = mimic.getYaw();
 		mimic.bodyYaw = mimic.getYaw();
 		for (int i = 0; i < type.size; i++) {


### PR DESCRIPTION
Fixes #52.

Pehkui changes the interaction range to be [calculated between the eye and bounding box](https://github.com/Virtuoel/Pehkui/blob/d4c49cadcb9bc857b1ea9540e1a3ce3592098886/src/main/java/virtuoel/pehkui/mixin/compat119plus/compat1193minus/ServerPlayNetworkHandlerMixin.java#L21-L79) rather than the eye and entity position.
It turns out that when initially creating the chest mimic entity, the bounding box was not being updated.
Using `refreshPositionAndAngles()` instead, updates the bounding box as expected (it ends up running `this.setBoundingBox(this.calculateBoundingBox())`).

Without Pehkui installed, there's a more minor bug that this fixes, where newly created pet mimics will not have collision.